### PR TITLE
doubled RAWBUF size to handle my A/C remote

### DIFF
--- a/IRremote.h
+++ b/IRremote.h
@@ -109,7 +109,7 @@ public:
 // Some useful constants
 
 #define USECPERTICK 50  // microseconds per clock interrupt tick
-#define RAWBUF 100 // Length of raw duration buffer
+#define RAWBUF 200 // Length of raw duration buffer
 
 // Marks tend to be 100us too long, and spaces 100us too short
 // when received due to sensor lag.


### PR DESCRIPTION
When decoding signals from the remote of my A/C (I have no idea what vendor..), I had to increase the size of RAWBUF, since I dealt with signals that needed 182-188 bins instead of the original 100.