### PR TITLE
add isIdle() method

### DIFF
--- a/IRremote.cpp
+++ b/IRremote.cpp
@@ -375,6 +375,10 @@ ISR(TIMER_INTR_NAME)
   }
 }
 
+bool IRrecv::isIdle() {
+  return (irparams.rcvstate == STATE_IDLE || irparams.rcvstate == STATE_STOP) ? true : false;
+}
+
 void IRrecv::resume() {
   irparams.rcvstate = STATE_IDLE;
   irparams.rawlen = 0;

--- a/IRremote.h
+++ b/IRremote.h
@@ -58,6 +58,7 @@ public:
   void blink13(int blinkflag);
   int decode(decode_results *results);
   void enableIRIn();
+  bool isIdle();
   void resume();
 private:
   // These are called by decode


### PR DESCRIPTION
Added isIdle() method to check if interrupt code is "receiving" a new IR
code.

With this information Wait until IRrecv is idle before starting another long running time critical
code with noInterrupts() inside like the NeoPixel code has to do with long LED strips.

    void show() {
      while (!irrecv.isIdle()) {
        delay(1);
      }
      strip.show();
    }
