### PR TITLE
Increased RawBuffer size

### DIFF
--- a/IRremote.h
+++ b/IRremote.h
@@ -119,7 +119,7 @@ public:
 // Some useful constants
 
 #define USECPERTICK 50  // microseconds per clock interrupt tick
-#define RAWBUF 100 // Length of raw duration buffer
+#define RAWBUF 400 // Length of raw duration buffer
 
 // Marks tend to be 100us too long, and spaces 100us too short
 // when received due to sensor lag.

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -200,7 +200,7 @@ typedef struct {
   uint8_t blinkflag;         // TRUE to enable blinking of pin 13 on IR processing
   unsigned int timer;     // state timer, counts 50uS ticks.
   unsigned int rawbuf[RAWBUF]; // raw data
-  uint8_t rawlen;         // counter of entries in rawbuf
+  uint16_t rawlen;         // counter of entries in rawbuf
 } 
 irparams_t;
 


### PR DESCRIPTION
I've had many problems to record the IR signal sent from my Fujitsu air cooler remote controller. I've found an issue regarding the length of the buffer. My fujitsu sent a 260 byte legth signat to turn on the air cooler. So I've increase the length of the buffer up to 400. I hope this can help. 